### PR TITLE
Add volume example

### DIFF
--- a/examples/examples3d.jl
+++ b/examples/examples3d.jl
@@ -625,3 +625,32 @@
         # scene
     # end
 end
+
+@block "Anshul Singhvi"  ["3d"] begin
+    
+    @cell "Volume on black background" [3d, volume] begin
+        
+        xs = LinRange(-3, 3, 100);  # x values
+        ys = copy(xs);              # y values
+        zs = copy(xs);              # z values
+
+        ρ(x, y, z) = exp(-(abs(x))) # function (charge density)
+
+        qs = [ρ(x, y , z) for x in xs, y in ys, z in zs]; # charge density
+
+        sc = Scene(backgroundcolor = :black) # create a Scene with the attribute `backgroundcolor = :black`, 
+        # can be any compatible color.  Useful for better contrast and not killing your eyes with a white background.
+        
+        volume!(sc, 
+            xs, ys, zs,       # coordinates to plot on
+            qs,               # charge density (functions as colorant)
+            algorithm = :mip  # maximum-intensity-projection
+        )
+        
+        sc[Axis][:names, :textcolor] = :gray # let axis labels be seen on dark background
+        
+        sc # show scene
+        
+    end
+    
+end

--- a/examples/examples3d.jl
+++ b/examples/examples3d.jl
@@ -630,27 +630,25 @@ end
     
     @cell "Volume on black background" [3d, volume] begin
         
-        xs = LinRange(-3, 3, 100);  # x values
-        ys = copy(xs);              # y values
-        zs = copy(xs);              # z values
+        r = LinRange(-3, 3, 100);  # our value range
 
         ρ(x, y, z) = exp(-(abs(x))) # function (charge density)
 
-        qs = [ρ(x, y , z) for x in xs, y in ys, z in zs]; # charge density
-
-        sc = Scene(backgroundcolor = :black) # create a Scene with the attribute `backgroundcolor = :black`, 
+        # create a Scene with the attribute `backgroundcolor = :black`, 
         # can be any compatible color.  Useful for better contrast and not killing your eyes with a white background.
-        
-        volume!(sc, 
-            xs, ys, zs,       # coordinates to plot on
-            qs,               # charge density (functions as colorant)
+        scene = Scene(backgroundcolor = :black) 
+
+        volume!(
+            scene, 
+            r, r, r,          # coordinates to plot on
+            ρ,                # charge density (functions as colorant)
             algorithm = :mip  # maximum-intensity-projection
         )
-        
-        sc[Axis][:names, :textcolor] = :gray # let axis labels be seen on dark background
-        
-        sc # show scene
-        
+
+        scene[Axis].names.textcolor = :gray # let axis labels be seen on dark background
+
+        scene # show scene
+
     end
     
 end


### PR DESCRIPTION
Add a black background volume plot to the Examples gallery.  This serves to illustrate not only the lovely volume feature but also theming!