### PR TITLE
Add recipes to make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -143,7 +143,7 @@ makedocs(
             "plot-attributes.md",
             "colors.md",
             "theming.md",
-            # "extending.md",
+            "recipes.md",
             "axis.md",
             "interaction.md",
             "output.md",


### PR DESCRIPTION
The recipes.md file is not currently in make.jl.  This is fixed here...