### PR TITLE
Update animation.md

### DIFF
--- a/docs/src/animation.md
+++ b/docs/src/animation.md
@@ -1,4 +1,4 @@
-# Animation
+# Animation 
 
 `Makie.jl` has extensive support for animations; you can create arbitrary plots, and save them to:
 - `.mkv`  (the default, doesn't need to convert)


### PR DESCRIPTION
test labeler.

If this does not work, then I think the issue is the file path currently used for files ending in "*.md".