### PR TITLE
clean up colored mesh example

### DIFF
--- a/examples/examples3d.jl
+++ b/examples/examples3d.jl
@@ -63,16 +63,12 @@
         mesh(MakieGallery.loadasset("cat.obj"))
     end
     @cell "Colored Mesh" [mesh, axis] begin
-        x = [0, 1, 2, 0]
-        y = [0, 0, 1, 2]
-        z = [0, 2, 0, 1]
+        # You can also use an array of x, y and z-values
+        points = Point3f0[[2, 2, 2], [1, 0, 2], [2, 1, 0], [0, 2, 1]]
         color = [:red, :green, :blue, :yellow]
-        i = [0, 0, 0, 1]
-        j = [1, 2, 3, 2]
-        k = [2, 3, 1, 3]
         # indices interpreted as triangles (every 3 sequential indices)
         indices = [1, 2, 3,   1, 3, 4,   1, 4, 2,   2, 3, 4]
-        mesh(x, y, z, indices, color = color)
+        mesh(points, indices, color = color)
     end
     @cell "Wireframe of a Mesh" [mesh, wireframe, cat] begin
         wireframe(MakieGallery.loadasset("cat.obj"))


### PR DESCRIPTION
I removed `i, j, k` arrays as they are not used. I changed the `x, y, z` arrays to an array of points, as that's a bit clearer imo. I also made the pyramid face the camera, so that you can see all points. Though I'm not sure whether that's actually helpful.

![Screenshot from 2020-07-13 00-23-38](https://user-images.githubusercontent.com/10947937/87257921-6b769880-c49f-11ea-90e9-60e608300143.png)
