### PR TITLE
Add tip for invoking dedicated GPU support

### DIFF
--- a/docs/src/backends.md
+++ b/docs/src/backends.md
@@ -22,3 +22,5 @@ Currently, installing it is not straightforward; see the [`WGLMakie.jl` README](
 
 CairoMakie uses Cairo to draw vector graphics to SVG and PDF.  
 It needs Cairo.jl to build properly, which may be difficult on MacOS.
+
+!!! tip "using GPU for rendering scenes in Linux" Normally the dedicated GPU is used for rendering scenes, but in case of mobile GPU's in Linux, one can tell Julia to use the dedicated GPU while launching julia as :``` $ sudo DRI_PRIME=1 julia``` in bash terminal. 


### PR DESCRIPTION
Even if the d-gpu drivers aren't compatible, there is a way to direct rendering processes to it. A flag viz. DRI_PRIME=1  aids this.
So something like sudo DRI_PRIME =1 julia will always forward the rendering applications to the integrated GPU(monitored from radeontop)